### PR TITLE
Add post to Mastodon functionality

### DIFF
--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -11,3 +11,4 @@ service_identity
 # cython is a lame requirement from rabbit hole of cartopy
 cython
 cartopy
+mastodon.py

--- a/src/iembot/basicbot.py
+++ b/src/iembot/basicbot.py
@@ -66,7 +66,9 @@ class basicbot:
         self.routingtable = {}
         self.tw_users = {}  # Storage by user_id => {screen_name: ..., oauth:}
         self.tw_routingtable = {}  # Storage by channel => [user_id, ]
-        self.md_users = {}  # Storage by user_id => {access_token: ..., api_base_url: ...}
+        self.md_users = (
+            {}
+        )  # Storage by user_id => {access_token: ..., api_base_url: ...}
         self.md_routingtable = {}  # Storage by channel => [user_id, ]
         self.webhooks_routingtable = {}
         self.xmlstream = None

--- a/src/iembot/iemchatbot.py
+++ b/src/iembot/iemchatbot.py
@@ -202,4 +202,33 @@ class JabberClient(basicbot.basicbot):
                     latitude=lat,
                     longitude=long,
                 )
+            for user_id in self.md_routingtable.get(channel, []):
+                if user_id not in self.md_users:
+                    log.msg(
+                        f"Failed to send to Mastodon due to no access_tokens {user_id}"
+                    )
+                    continue
+                # Require the x.twitter attribute to be set to prevent
+                # confusion with some ingestors still sending tweets themselfs
+                if not elem.x.hasAttribute("twitter"):
+                    continue
+                if user_id in alertedPages:
+                    continue
+                alertedPages.append(user_id)
+                lat = long = None
+                if (
+                    elem.x
+                    and elem.x.hasAttribute("lat")
+                    and elem.x.hasAttribute("long")
+                ):
+                    lat = elem.x["lat"]
+                    long = elem.x["long"]
+                # Finally, actually post to Mastodon, this is in basicbot
+                self.toot(
+                    user_id,
+                    elem.x["twitter"],
+                    twitter_media=elem.x.getAttribute("twitter_media"),
+                    latitude=lat,  # TODO: unused
+                    longitude=long,  # TODO: unused
+                )
         webhooks_route(self, channels, elem)

--- a/src/iembot/util.py
+++ b/src/iembot/util.py
@@ -15,10 +15,11 @@ from email.mime.text import MIMEText
 from html import unescape
 from io import BytesIO
 
+import mastodon
+
 # Third Party
 import pytz
 import twitter
-import mastodon
 from pyiem.reference import TWEET_CHARS
 from pyiem.util import utc
 from requests_oauthlib import OAuth1
@@ -130,7 +131,9 @@ def toot(bot, user_id, twttxt, **kwargs):
         }
         # If we have media, we have some work to do!
         if media is not None:
-            media_id = api.media_post(media, mime_type="image/png")  # TODO: Is this always image/png?
+            media_id = api.media_post(
+                media, mime_type="image/png"
+            )  # TODO: Is this always image/png?
             params["media_ids"] = [media_id]
         res = api.status_post(**params)
     except mastodon.errors.MastodonRateLimitError as exp:
@@ -456,7 +459,9 @@ def disable_mastodon_user(bot, user_id, errcode=0):
         return False
     screen_name = mduser["screen_name"]
     if mduser["iem_owned"]:
-        log.msg(f"Skipping disabling of Mastodon for {user_id} ({screen_name})")
+        log.msg(
+            f"Skipping disabling of Mastodon for {user_id} ({screen_name})"
+        )
         return False
     bot.md_users.pop(user_id, None)
     log.msg(
@@ -485,10 +490,12 @@ def toot_cb(response, bot, twttxt, room, myjid, user_id):
     if "content" not in response:
         log.msg(f"Got response without content {repr(response)}")
         return
-    screen_name = mduser["screen_name"]
+    mduser["screen_name"]
     url = response["url"]
 
-    response.pop("account", None)  # Remove extra junk, there's still a lot more though...
+    response.pop(
+        "account", None
+    )  # Remove extra junk, there's still a lot more though...
 
     # Log
     df = bot.dbpool.runOperation(

--- a/src/iembot/util.py
+++ b/src/iembot/util.py
@@ -18,6 +18,7 @@ from io import BytesIO
 # Third Party
 import pytz
 import twitter
+import mastodon
 from pyiem.reference import TWEET_CHARS
 from pyiem.util import utc
 from requests_oauthlib import OAuth1
@@ -103,6 +104,55 @@ def tweet(bot, user_id, twttxt, **kwargs):
         time.sleep(10)
         params.pop("media", None)
         res = _helper(params)
+    return res
+
+
+def toot(bot, user_id, twttxt, **kwargs):
+    """Blocking Mastodon toot method."""
+    if user_id not in bot.md_users:
+        log.msg(f"toot() called with unknown Mastodon user_id: {user_id}")
+        return None
+    api = mastodon.Mastodon(
+        access_token=bot.config["bot.mastodon.access_token"],
+        api_base_url=bot.config["bot.mastodon.api_base_url"],
+    )
+    log.msg(
+        f"Sending to Mastodon {bot.md_users[user_id]['screen_name']}({user_id}) "
+        f"'{twttxt}' media:{kwargs.get('twitter_media')}"
+    )
+    media = kwargs.get("twitter_media")
+    media_id = None
+
+    res = None
+    try:
+        params = {
+            "status": twttxt,
+        }
+        # If we have media, we have some work to do!
+        if media is not None:
+            media_id = api.media_post(media, mime_type="image/png")  # TODO: Is this always image/png?
+            params["media_ids"] = [media_id]
+        res = api.status_post(**params)
+    except mastodon.errors.MastodonRateLimitError as exp:
+        # Submitted too quickly
+        log.err(exp)
+        # Since this called from a thread, sleeping should not jam us up
+        time.sleep(10)
+        res = api.status_post(**params)
+    except mastodon.errors.MastodonError as exp:
+        # Something else bad happened when submitting this to the Mastodon server
+        log.err(exp)
+        params.pop("media_ids", None)  # Try again without media
+        # Since this called from a thread, sleeping should not jam us up
+        time.sleep(10)
+        res = api.status_post(**params)
+    except Exception as exp:
+        # Something beyond Mastodon went wrong
+        log.err(exp)
+        params.pop("media_ids", None)  # Try again without media
+        # Since this called from a thread, sleeping should not jam us up
+        time.sleep(10)
+        res = api.status_post(**params)
     return res
 
 
@@ -393,6 +443,80 @@ def twitter_errback(err, bot, user_id, tweettext):
         email_error(err, bot, msg)
 
 
+def disable_mastodon_user(bot, user_id, errcode=0):
+    """Disable the Mastodon subs for this user_id
+
+    Args:
+        user_id (big_id): The Mastodon user to disable
+        errcode (int): The HTTP-like errorcode
+    """
+    mduser = bot.md_users.get(user_id)
+    if mduser is None:
+        log.msg(f"Failed to disable unknown Mastodon user_id {user_id}")
+        return False
+    screen_name = mduser["screen_name"]
+    if mduser["iem_owned"]:
+        log.msg(f"Skipping disabling of Mastodon for {user_id} ({screen_name})")
+        return False
+    bot.md_users.pop(user_id, None)
+    log.msg(
+        f"Removing Mastodon access token for user: {user_id} ({screen_name}) "
+        f"errcode: {errcode}"
+    )
+    df = bot.dbpool.runOperation(
+        f"UPDATE {bot.name}_mastodon_oauth SET updated = now(), "
+        "access_token = null, api_base_url = null "
+        "WHERE user_id = %s",
+        (user_id,),
+    )
+    df.addErrback(log.err)
+    return True
+
+
+def toot_cb(response, bot, twttxt, room, myjid, user_id):
+    """
+    Called after success going to Mastodon
+    """
+    if response is None:
+        return
+    mduser = bot.md_users.get(user_id)
+    if mduser is None:
+        return response
+    if "content" not in response:
+        log.msg(f"Got response without content {repr(response)}")
+        return
+    screen_name = mduser["screen_name"]
+    url = response["url"]
+
+    response.pop("account", None)  # Remove extra junk, there's still a lot more though...
+
+    # Log
+    df = bot.dbpool.runOperation(
+        f"INSERT into {bot.name}_social_log(medium, source, resource_uri, "
+        "message, response, response_code) values (%s,%s,%s,%s,%s,%s)",
+        ("mastodon", myjid, url, twttxt, repr(response), 200),
+    )
+    df.addErrback(log.err)
+    return response
+
+
+def mastodon_errback(err, bot, user_id, tweettext):
+    """Error callback when simple Mastodon workflow fails."""
+    # Always log it
+    log.err(err)
+    errcode = None
+    if isinstance(err, mastodon.errors.MastodonNotFoundError):
+        errcode = 404
+        disable_mastodon_user(bot, user_id, errcode)
+    elif isinstance(err, mastodon.errors.MastodonUnauthorizedError):
+        errcode = 401
+        disable_mastodon_user(bot, user_id, errcode)
+    else:
+        sn = bot.md_users.get(user_id, {}).get("screen_name", "")
+        msg = f"User: {user_id} ({sn})\n" f"Failed to toot: {tweettext}"
+        email_error(err, bot, msg)
+
+
 def load_chatrooms_from_db(txn, bot, always_join):
     """Load database configuration and do work
 
@@ -542,6 +666,44 @@ def load_twitter_from_db(txn, bot):
         }
     bot.tw_users = twusers
     log.msg(f"load_twitter_from_db(): {txn.rowcount} oauth tokens found")
+
+
+def load_mastodon_from_db(txn, bot):
+    """Load Mastodon config from database"""
+    # Don't waste time by loading up subs from unauthed users
+    txn.execute(
+        f"select s.user_id, channel from {bot.name}_mastodon_subs s "
+        "JOIN iembot_mastodon_oauth o on (s.user_id = o.user_id) "
+        "WHERE s.user_id is not null and s.channel is not null "
+        "and o.access_token is not null and not o.disabled"
+    )
+    mdrt = {}
+    for row in txn.fetchall():
+        user_id = row["user_id"]
+        channel = row["channel"]
+        d = mdrt.setdefault(channel, [])
+        d.append(user_id)
+    bot.md_routingtable = mdrt
+    log.msg(f"load_mastodon_from_db(): {txn.rowcount} subs found")
+
+    mdusers = {}
+    txn.execute(
+        "SELECT user_id, access_token, api_base_url, screen_name, "
+        "iem_owned from "
+        f"{bot.name}_mastodon_oauth WHERE access_token is not null and "
+        "api_base_url is not null and user_id is not null and "
+        "screen_name is not null and not disabled"
+    )
+    for row in txn.fetchall():
+        user_id = row["user_id"]
+        mdusers[user_id] = {
+            "screen_name": row["screen_name"],
+            "access_token": row["access_token"],
+            "api_base_url": row["api_base_url"],
+            "iem_owned": row["iem_owned"],
+        }
+    bot.md_users = mdusers
+    log.msg(f"load_mastodon_from_db(): {txn.rowcount} access tokens found")
 
 
 def load_chatlog(bot):


### PR DESCRIPTION
RIP iembot on Twitter... or X... or whatever it ends up being called by the time this is merged or rejected. Here's an option to keep its legacy going on another social media platform... before it gets killed by Meta.

This is pretty much a straight copy of the tweet functions, methods, and assumed db structure but using the [Mastodon.py](https://mastodonpy.readthedocs.io/en/stable/index.html) library.

Even though most Mastodon instances allow for lengthier posts, my preference is for these posts to have the same brevity as tweets did (I find [the RSS-fed bots](https://bots.krohsnest.com/@iembot_mkx) to be little more than spam for the timeline), so the same text and media are used here.

Some key differences:
- The API only requires an access token, but each user must specify their API URL (i.e. Mastodon instance).
- Media MIME types are not inferred, right now I'm assuming all media is `image/png`.
- Error handling is not as robust, though we can tell if an access token is invalid (401) or the API URL doesn't exist (404).
- The API response object is a dict containing *all* metadata, which probably doesn't need to be logged in full.

While [I have played around with Mastodon.py a bit](https://hachyderm.io/@jpatton/110789546131041976), this code has not been tested in the `iembot` context at all, and I haven't dared to code anything yet for users to upload their own access tokens. Speaking of access tokens, I'll open a related PR at https://github.com/akrherz/iem-database as well and link it back here.