### PR TITLE
✨ Add slack /list command

### DIFF
--- a/src/iembot/slack.py
+++ b/src/iembot/slack.py
@@ -212,8 +212,7 @@ class SlackListChannel(resource.Resource):
                 f"Current channel subscriptions {subs}".encode("ascii")
             )
         )
-        defer.addCallback(lambda _: request.finish())
-
+        defer.addBoth(lambda _: request.finish())
         return NOT_DONE_YET
 
 
@@ -260,7 +259,7 @@ class SlackUnsubscribeChannel(resource.Resource):
                 f"Unsubscribed from {subkey}".encode("ascii")
             )
         )
-        defer.addCallback(lambda _: request.finish())
+        defer.addBoth(lambda _: request.finish())
         defer.addCallback(lambda _: self.iembot.load_slack())
 
         return NOT_DONE_YET

--- a/src/iembot/slack.py
+++ b/src/iembot/slack.py
@@ -169,6 +169,54 @@ class SlackSubscribeChannel(resource.Resource):
         return NOT_DONE_YET
 
 
+class SlackListChannel(resource.Resource):
+    """respond to /list requests"""
+
+    def __init__(self, iembot: JabberClient):
+        """Constructor"""
+        resource.Resource.__init__(self)
+        self.iembot = iembot
+
+    def list_slack_subscriptions(
+        self,
+        txn,
+        team_id,
+        channel_id,
+    ) -> str:
+        """write to database."""
+        txn.execute(
+            """
+            select channel_name from
+            iembot_subscriptions s JOIN iembot_channels c
+                ON (s.channel_id = c.id)
+            WHERE iembot_account_id = (
+            select iembot_account_id from iembot_slack_team_channels where
+            team_id = %s and channel_id = %s)
+            """,
+            (team_id, channel_id),
+        )
+        res = ", ".join([row["channel_name"] for row in txn.fetchall()])
+        return res
+
+    def render(self, request):
+        """Answer the call."""
+        team_id = request.args.get(b"team_id", [b""])[0].decode("ascii")
+        channel_id = request.args.get(b"channel_id", [b""])[0].decode("ascii")
+        defer = self.iembot.dbpool.runInteraction(
+            self.list_slack_subscriptions,
+            team_id,
+            channel_id,
+        )
+        defer.addCallback(
+            lambda subs: request.write(
+                f"Current channel subscriptions {subs}".encode("ascii")
+            )
+        )
+        defer.addCallback(lambda _: request.finish())
+
+        return NOT_DONE_YET
+
+
 class SlackUnsubscribeChannel(resource.Resource):
     """respond to /unsubscribe requests"""
 

--- a/src/iembot/webservices.py
+++ b/src/iembot/webservices.py
@@ -14,6 +14,7 @@ from twisted.web.http import Request
 import iembot.util as botutil
 from iembot.slack import (
     SlackInstallChannel,
+    SlackListChannel,
     SlackOauthChannel,
     SlackSubscribeChannel,
     SlackUnsubscribeChannel,
@@ -224,3 +225,4 @@ class JSONRootResource(resource.Resource):
         self.putChild(b"unsubscribe", SlackUnsubscribeChannel(iembot))
         self.putChild(b"install", SlackInstallChannel(iembot))
         self.putChild(b"oauth_callback", SlackOauthChannel(iembot))
+        self.putChild(b"list", SlackListChannel(iembot))

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -12,12 +12,31 @@ from twisted.words.xish.domish import Element
 
 from iembot.slack import (
     SlackInstallChannel,
+    SlackListChannel,
     SlackSubscribeChannel,
     load_slack_from_db,
     route,
     send_to_slack,
 )
 from iembot.types import JabberClient
+
+
+@pytest_twisted.inlineCallbacks
+def test_list_channel_render(bot: JabberClient):
+    """Test that we can run the render workflow."""
+    ss = SlackListChannel(bot)
+    request = DummyRequest([])
+    request.args = {
+        b"team_id": [b"T12345"],
+        b"channel_id": [b"C67890"],
+    }
+    bot.dbpool.runInteraction = mock.Mock(
+        return_value=defer.succeed(["AFDDMX", "AFDDFG"])
+    )
+    result = ss.render(request)
+    assert result == NOT_DONE_YET
+    yield defer.succeed(None)
+    assert b"Current channel subscriptions" in b"".join(request.written)
 
 
 @pytest_twisted.inlineCallbacks


### PR DESCRIPTION
closes #191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Slack web endpoint for listing current channel subscriptions.
  * Exposed the feature under the app’s JSON Slack routes.

* **Tests**
  * Added coverage for the subscription-listing flow, including request handling and response output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->